### PR TITLE
Fix the data type name in the comment

### DIFF
--- a/snippets/fsharp/contour/snippet25.fs
+++ b/snippets/fsharp/contour/snippet25.fs
@@ -1,4 +1,4 @@
-// Make a list of values instead of identifiers.
+// Make a tuple of values instead of identifiers.
 let funAndArgTuple2 = ((fun n -> n * n), 10)
 
 // The following expression applies a squaring function to 10, returns


### PR DESCRIPTION
## Summary

Just changing the data type name in the comments. The sample shows an example of *tuple*, not a list.
